### PR TITLE
fix warnings, create and update in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ struct Post {
     #[cms(skip_column)]
     #[serde(default)]
     content: Json<Vec<Block>>,
+    #[serde(default)]
     draft: bool,
 }
 
@@ -78,6 +79,7 @@ impl entity::Update<Ctx> for Post {
         mut data: <Self as EntityBase<Ctx>>::Update,
         ext: Self::RequestExt,
     ) -> Result<Self, Self::Error> {
+        data.id = *id;
         Ok(data.update_all_fields(ext.ext()).await?)
     }
 }
@@ -90,7 +92,7 @@ impl entity::Delete<Ctx> for Post {
         id: &<Self as EntityBase<Ctx>>::Id,
         ext: Self::RequestExt,
     ) -> Result<(), Self::Error> {
-        let r = sqlx::query("DELETE FROM post WHERE id = ?")
+        sqlx::query("DELETE FROM post WHERE id = ?")
             .bind(id)
             .execute(ext.ext())
             .await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@
 //!     #[cms(skip_column)]
 //!     #[serde(default)]
 //!     content: Json<Vec<Block>>,
+//!     #[serde(default)]
 //!     draft: bool,
 //! }
 //!
@@ -103,6 +104,7 @@
 //!         mut data: <Self as EntityBase<Ctx>>::Update,
 //!         ext: Self::RequestExt,
 //!     ) -> Result<Self, Self::Error> {
+//!         data.id = *id;
 //!         Ok(data.update_all_fields(ext.ext()).await?)
 //!     }
 //! }
@@ -115,7 +117,7 @@
 //!         id: &<Self as EntityBase<Ctx>>::Id,
 //!         ext: Self::RequestExt,
 //!     ) -> Result<(), Self::Error> {
-//!         let r = sqlx::query("DELETE FROM post WHERE id = ?")
+//!         sqlx::query("DELETE FROM post WHERE id = ?")
 //!             .bind(id)
 //!             .execute(ext.ext())
 //!             .await?;


### PR DESCRIPTION
This fixes some warnings in the README / `lib.rs` example.

Also, it allows creating posts with `draft = false` (since in this case, the parameter is apparently not part of the post request) and updating posts.