### PR TITLE
move required attribute to non-hidden input

### DIFF
--- a/src/property.rs
+++ b/src/property.rs
@@ -227,8 +227,8 @@ where
         let input_id = Uuid::new_v4();
         let hidden_id = Uuid::new_v4();
         html! {
-            input type="datetime-local" id=(input_id) class="cms-datetime-input" {}
-            input type="hidden" name=(name) id=(hidden_id) value=[value.map(|v|v.to_rfc3339())] required[required] {}
+            input type="datetime-local" id=(input_id) class="cms-datetime-input" required[required] {}
+            input type="hidden" name=(name) id=(hidden_id) value=[value.map(|v|v.to_rfc3339())] {}
             script type="module" {(PreEscaped(format!(r#"
 const input = document.getElementById("{input_id}");
 const hidden = document.getElementById("{hidden_id}");


### PR DESCRIPTION
This moves the `required` attribute of the `DateTime` input to the non-hidden version, since `required` is not supported on `hidden` fields.[^1]

[^1]: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/required