### PR TITLE
allow including custom localizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ axum = { version = "0.7.3", features = ["multipart"] }
 cfg-if = "1.0.0"
 chrono = { version = "0.4.31", features = ["serde"] }
 convert_case = "0.6.0"
-derive_more = { version = "1.0.0", features = ["deref", "deref_mut", "display", "from", "from_str", "into"] }
+derive_more = { version = "1.0.0", features = ["debug", "deref", "deref_mut", "display", "from", "from_str", "into"] }
 derived-cms-derive = { version = "0.1.0", path = "derived-cms-derive" }
 format-sql-query = "0.4.0"
 generic-array = "1.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,7 +148,7 @@
 //!
 //! A REST API is automatically generated for all `Entities`.
 //!
-//! List of generated endpoints, with [`name`](Entity::name) and [`name-plural`](Entity::name_plural)
+//! List of generated endpoints, with [`name`](EntityBase::name) and [`name-plural`](EntityBase::name_plural)
 //! converted to [kebab-case](convert_case::Case::Kebab):
 //!
 //! - `GET /api/v1/:name-plural`:


### PR DESCRIPTION
This lays some groundwork that allows consumer libraries to easily add their own translations or override strings used in the web interface.

By allowing to include own `I18nAssets` in the App, they will get loaded on every request with the correct language. In `render`, the i18n object will have access to the consumers custom translations. However, the `domain` will still be `derived_cms`.

The only problem is, that we have to remove `Clone` from `App`. But that shouldn't really be important?