### PR TITLE
fix TS export for Json

### DIFF
--- a/src/property.rs
+++ b/src/property.rs
@@ -654,6 +654,24 @@ impl<T: TS + ?Sized> TS for Json<T> {
     fn inline_flattened() -> String {
         T::inline_flattened()
     }
+
+    fn visit_dependencies(visitor: &mut impl ts_rs::TypeVisitor)
+    where
+        Self: 'static,
+    {
+        T::visit_dependencies(visitor)
+    }
+
+    fn visit_generics(visitor: &mut impl ts_rs::TypeVisitor)
+    where
+        Self: 'static,
+    {
+        T::visit_generics(visitor)
+    }
+
+    fn output_path() -> Option<&'static Path> {
+        T::output_path()
+    }
 }
 
 #[cfg(feature = "json")]


### PR DESCRIPTION
This fixes the generated `TS` code for the `Json` type, since the dependencies were no longer automatically imported.