### PR TITLE
move json into feature guarded module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
+# helix project settings
+/.helix/
+
 
 # Added by cargo
 


### PR DESCRIPTION
This fixes compilation without the `json` feature and moves the relevant code into one single module that can be enabled.