### PR TITLE
Editor improvements

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -2,11 +2,14 @@ use std::path::{Path, PathBuf};
 
 use axum::extract::FromRef;
 
+use crate::easymde::EditorConfig;
+
 /// Trait implemented by the context available in all endpoints using [`axum::extract::State`].
 pub trait ContextTrait: Clone + Send + Sync + 'static {
     type Ext: ContextExt<Self>;
 
     fn names_plural(&self) -> impl Iterator<Item = impl AsRef<str>>;
+    fn editor(&self) -> Option<&EditorConfig>;
     fn uploads_dir(&self) -> &Path;
     fn ext(&self) -> &Self::Ext;
 }
@@ -14,6 +17,7 @@ pub trait ContextTrait: Clone + Send + Sync + 'static {
 #[derive(Debug)]
 pub struct Context<T: ContextExt<Self>> {
     pub(crate) names_plural: Vec<&'static str>,
+    pub(crate) editor_config: Option<EditorConfig>,
     pub(crate) uploads_dir: PathBuf,
     pub(crate) ext: T,
 }
@@ -22,6 +26,7 @@ impl<E: ContextExt<Self>> Clone for Context<E> {
         Self {
             names_plural: self.names_plural.clone(),
             uploads_dir: self.uploads_dir.clone(),
+            editor_config: self.editor_config.clone(),
             ext: self.ext.clone(),
         }
     }
@@ -31,6 +36,9 @@ impl<E: ContextExt<Self> + 'static> ContextTrait for Context<E> {
 
     fn names_plural(&self) -> impl Iterator<Item = impl AsRef<str>> {
         self.names_plural.iter()
+    }
+    fn editor(&self) -> Option<&EditorConfig> {
+        self.editor_config.as_ref()
     }
     fn uploads_dir(&self) -> &Path {
         &self.uploads_dir

--- a/src/easymde.rs
+++ b/src/easymde.rs
@@ -1,0 +1,106 @@
+use std::{borrow::Cow, path::PathBuf};
+
+use axum::{extract::multipart::MultipartError, http::StatusCode, response::IntoResponse, Json};
+use serde::Serialize;
+use tracing::error;
+
+#[derive(Debug, Clone)]
+pub struct EditorConfig {
+    /// enable drag-and-drop upload functionality in the default markdown editor
+    pub(crate) enable_uploads: bool,
+    /// max upload size in bytes
+    pub(crate) upload_max_size: u32,
+    /// Allowed file types to upload. Default: image/png, image/jpeg
+    pub(crate) allowed_file_types: Vec<Cow<'static, str>>,
+}
+
+impl Default for EditorConfig {
+    fn default() -> Self {
+        Self {
+            enable_uploads: true,
+            upload_max_size: 1024 * 1024 * 2,
+            allowed_file_types: vec!["image/png".into(), "image/jpeg".into()],
+        }
+    }
+}
+
+impl EditorConfig {
+    /// Enable uploads directly in the editor.
+    pub fn enable_uploads(mut self, enable: bool) -> Self {
+        self.enable_uploads = enable;
+        self
+    }
+
+    /// Set the max size for uploads.
+    pub fn upload_max_size(mut self, max_size: u32) -> Self {
+        self.upload_max_size = max_size;
+        self
+    }
+
+    /// Add an allowed file type to the currently allowed file types.
+    pub fn allow_file_type(mut self, file_type: impl Into<Cow<'static, str>>) -> Self {
+        self.allowed_file_types.push(file_type.into());
+        self
+    }
+
+    /// Reset the allowed file types to the given list.
+    pub fn allowed_file_types(mut self, file_types: Vec<Cow<'static, str>>) -> Self {
+        self.allowed_file_types = file_types;
+        self
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct UploadedFileInfo {
+    file_path: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct UploadSuccess {
+    data: UploadedFileInfo,
+}
+
+impl UploadSuccess {
+    pub fn new(file_path: impl Into<PathBuf>) -> Self {
+        Self {
+            data: UploadedFileInfo {
+                file_path: file_path.into(),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase", tag = "error")]
+pub(crate) enum UploadError {
+    NoFileGiven,
+    TypeNotAllowed,
+    FileTooLarge,
+    ImportError,
+}
+
+impl From<MultipartError> for UploadError {
+    fn from(err: MultipartError) -> Self {
+        error!("multipart error while uploading from editor: {err}");
+        match err.status() {
+            StatusCode::PAYLOAD_TOO_LARGE => UploadError::FileTooLarge,
+            _ => UploadError::ImportError,
+        }
+    }
+}
+
+impl IntoResponse for UploadError {
+    fn into_response(self) -> axum::response::Response {
+        let status_code = StatusCode::from_u16(match self {
+            UploadError::NoFileGiven | UploadError::ImportError => 400,
+            UploadError::TypeNotAllowed => 415,
+            UploadError::FileTooLarge => 413,
+        })
+        .unwrap();
+        let mut resp = Json::from(self).into_response();
+        *resp.status_mut() = status_code;
+
+        resp
+    }
+}

--- a/src/endpoints/ui.rs
+++ b/src/endpoints/ui.rs
@@ -1,9 +1,12 @@
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
 use axum::{
-    extract::{multipart::MultipartError, Multipart, Path, State},
+    extract::{
+        multipart::{Field, MultipartError},
+        Multipart, Path, State,
+    },
     response::{IntoResponse, Redirect},
-    Extension,
+    Extension, Json,
 };
 use convert_case::{Case, Casing};
 use i18n_embed::fluent::FluentLanguageLoader;
@@ -14,7 +17,14 @@ use tokio::io::AsyncWriteExt;
 use tracing::{debug, error};
 use uuid::Uuid;
 
-use crate::{app::AppError, context::ContextTrait, entity, render, Entity};
+use crate::{
+    app::AppError,
+    context::ContextTrait,
+    easymde::{EditorConfig, UploadError, UploadSuccess},
+    entity,
+    property::File,
+    render, Entity,
+};
 
 pub async fn get_entities<E: Entity<S>, S: ContextTrait>(
     ctx: State<S>,
@@ -145,11 +155,42 @@ enum ParseFormError {
     ),
     #[error("File names must not contain '/': {0}")]
     FilenameSlash(String),
+    #[error("Field must contain filename")]
+    FilenameMissing,
     #[error("Failed to deserialize: {serde:#}: {query_string}")]
     Deserialize {
         serde: serde_qs::Error,
         query_string: String,
     },
+}
+
+async fn stream_field_to_file<'a>(
+    mut field: Field<'a>,
+    output_dir: &'a std::path::Path,
+) -> Result<File, ParseFormError> {
+    let id = Uuid::new_v4();
+    let Some(filename) = field.file_name().filter(|name| !name.is_empty()) else {
+        return Err(ParseFormError::FilenameMissing);
+    };
+    if filename.contains('/') {
+        return Err(ParseFormError::FilenameSlash(filename.to_string()));
+    }
+
+    let folder_path = output_dir.join(id.to_string());
+    tokio::fs::create_dir_all(&folder_path).await?;
+
+    let file_path = folder_path.join(&filename);
+
+    // clone such that we don't keep a reference to filename for too long
+    let filename = filename.to_string();
+
+    let mut file = tokio::fs::File::create_new(file_path).await?;
+
+    while let Some(v) = field.chunk().await? {
+        file.write_all(&v).await?;
+    }
+
+    Ok(File::new_with_id(id, filename))
 }
 
 /// Parse multipart/form-data with nested fields like in [serde_qs].
@@ -169,25 +210,16 @@ async fn parse_form<T: for<'de> Deserialize<'de>>(
     let mut qs = String::new();
     while let Some(field) = form.next_field().await? {
         let name = field.name().ok_or(ParseFormError::NameMissing)?;
-        let name = urlencoding::encode(name);
+        let name = urlencoding::encode(name).to_string();
         match field.file_name() {
             Some(filename) if !filename.is_empty() => {
-                let id = Uuid::new_v4();
-                if filename.contains('/') {
-                    return Err(ParseFormError::FilenameSlash(filename.to_string()));
-                }
-                let filename_escaped = urlencoding::encode(filename);
+                let file = stream_field_to_file(field, files_dir).await?;
+                let filename_escaped = urlencoding::encode(&file.name);
+                let id = file.id;
                 if !qs.is_empty() {
                     qs.push('&');
                 }
                 qs.push_str(&format!("{name}[name]={filename_escaped}&{name}[id]={id}"));
-                let path = files_dir.join(id.to_string());
-                tokio::fs::create_dir_all(&path).await?;
-                let path = path.join(filename);
-                tokio::fs::File::create(path)
-                    .await?
-                    .write_all(&field.bytes().await?)
-                    .await?;
                 // TODO: delete newly created files on error
             }
             None => {
@@ -209,4 +241,32 @@ async fn parse_form<T: for<'de> Deserialize<'de>>(
             serde: e,
             query_string: qs,
         })
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct UploadDir(pub(crate) PathBuf);
+
+pub(crate) async fn parse_mde_upload(
+    config: Extension<EditorConfig>,
+    path: Extension<UploadDir>,
+    mut form: Multipart,
+) -> Result<Json<UploadSuccess>, UploadError> {
+    let upload_dir = path.0 .0;
+    while let Some(field) = form.next_field().await? {
+        let accepted = match field.content_type() {
+            Some(content_type) => config.allowed_file_types.contains(&content_type.into()),
+            None => false,
+        };
+        if !accepted {
+            return Err(UploadError::TypeNotAllowed);
+        }
+        return match stream_field_to_file(field, &upload_dir).await {
+            Ok(file) => Ok(Json::from(UploadSuccess::new(file.url()))),
+            Err(err) => {
+                error!("writing uploaded file failed: {err}");
+                Err(UploadError::ImportError)
+            }
+        };
+    }
+    Err(UploadError::NoFileGiven)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,6 +177,7 @@ pub use input::Input;
 pub mod app;
 pub mod column;
 pub mod context;
+pub mod easymde;
 mod endpoints;
 pub mod entity;
 pub mod input;

--- a/src/property.rs
+++ b/src/property.rs
@@ -746,12 +746,18 @@ impl Column for Uuid {
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, TS)]
 pub struct File {
     /// name of the file created in `files_dir`
-    id: Uuid,
+    pub(crate) id: Uuid,
     /// original filename
-    name: String,
+    pub(crate) name: String,
 }
 
 impl File {
+    pub fn new(file_name: String) -> Self {
+        Self::new_with_id(Uuid::new_v4(), file_name)
+    }
+    pub fn new_with_id(id: Uuid, name: String) -> Self {
+        Self { id, name }
+    }
     pub fn url(&self) -> String {
         format!("/uploads/{}/{}", self.id, self.name)
     }


### PR DESCRIPTION
This PR contains several things:

- The EasyMDE editor is no longer included by default (which is probably good, because we currently rely on the CDN).
- It allows enabling drag-and-drop / copy-paste uploads and exposes relevant configuration values to the library user.